### PR TITLE
Implement RSC (lightly tested) / Cleanup hyperparameter registry

### DIFF
--- a/domainbed/algorithms.py
+++ b/domainbed/algorithms.py
@@ -714,7 +714,7 @@ class SagNet(Algorithm):
                 'loss_adv': loss_adv.item()}
 
     def predict(self, x):
-        return self.content_net(self.featurizer(x))
+        return self.network_c(self.network_f(x))
 
 class RSC(ERM):
     """

--- a/domainbed/algorithms.py
+++ b/domainbed/algorithms.py
@@ -3,7 +3,6 @@
 import copy
 
 import numpy as np
-import numpy.random as npr
 import torch
 import torch.autograd as autograd
 import torch.nn as nn

--- a/domainbed/algorithms.py
+++ b/domainbed/algorithms.py
@@ -3,10 +3,12 @@
 import copy
 
 import numpy as np
+import numpy.random as npr
 import torch
 import torch.autograd as autograd
 import torch.nn as nn
 import torch.nn.functional as F
+import random
 
 from domainbed import networks
 from domainbed.lib.misc import random_pairs_of_minibatches
@@ -24,6 +26,7 @@ ALGORITHMS = [
     'MTL', 
     'SagNet',
     'ARM',
+    'RSC'
 ]
 
 def get_algorithm_class(algorithm_name):
@@ -74,6 +77,8 @@ class ERM(Algorithm):
     def update(self, minibatches):
         all_x = torch.cat([x for x,y in minibatches])
         all_y = torch.cat([y for x,y in minibatches])
+        print(all_x.shape)
+        print(all_y.shape)
         loss = F.cross_entropy(self.predict(all_x), all_y)
 
         self.optimizer.zero_grad()
@@ -711,4 +716,151 @@ class SagNet(Algorithm):
                 'loss_adv': loss_adv.item()}
 
     def predict(self, x):
-        return self.network_c(self.network_f(x))
+        return self.content_net(self.featurizer(x))
+
+class RSC(ERM):
+    """
+        Representation Self-Challenging (RSC)
+        from: https://arxiv.org/pdf/2007.02454.pdf
+    """
+    def __init__(self, input_shape, num_classes, num_domains, hparams):
+        super(RSC, self).__init__(input_shape, num_classes, num_domains,
+                              hparams)
+
+        self.f_drop_factor = hparams['rsc_f_drop_factor']
+        self.b_drop_factor = hparams['rsc_b_drop_factor']
+        self.num_classes = num_classes
+        self.flatten = nn.Flatten()
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
+        self.featurizer_name = self.featurizer.__class__.__name__
+
+        """
+        For ResNet (original paper):
+            Delete the Average Pooling since this method operates on features after conv layer 4 
+            Dropout is disabled in hyperparameters both for default and random
+            Flatten from original ResNet is temporarily reverted for computations during update since it is not accessible as a layer     
+        For MNIST_CNN (custom):
+            Delete the Average Pooling and use features after bn3
+            SqueezeLastTwo is accessible as a Layer so we can delete it and replace it through Identity, serves as our flatten operation later
+
+           Disclaimer: Apparently this algorithm doesn't work very well for the MNIST datasets with the current architecture
+        """
+
+        if self.featurizer_name == "ResNet":
+            del self.featurizer.network.avgpool
+            self.featurizer.network.avgpool = networks.Identity()
+        elif self.featurizer_name == "MNIST_CNN":
+            del self.featurizer.avgpool
+            self.featurizer.avgpool = networks.Identity()
+            del self.featurizer.squeezeLastTwo
+            self.featurizer.squeezeLastTwo = networks.Identity()
+            self.flatten = networks.SqueezeLastTwo()
+
+        self.network = nn.Sequential(self.featurizer, self.avgpool, self.flatten, self.classifier)
+        self.optimizer = torch.optim.Adam(
+            self.network.parameters(),
+            lr=self.hparams["lr"],
+            weight_decay=self.hparams['weight_decay']
+        )
+
+    def create_onehots(self, num_samples, targets):
+        one_hots = torch.zeros(num_samples, self.num_classes)  # By default this sets requires_grad = False
+        one_hots[range(one_hots.shape[0]), targets] = 1
+        return one_hots.cuda()
+
+    def construct_mask(self, mean, num_samples, size):
+        num_to_drop = int(size * self.f_drop_factor)
+        mask_values = torch.sort(mean, dim=1, descending=True)[0][:, num_to_drop]
+        mask_values = mask_values.view(num_samples, 1).expand(num_samples, size)
+        mask = torch.where(mean >= mask_values, torch.zeros(mean.shape).cuda(), torch.ones(mean.shape).cuda())
+        return mask
+
+    def update(self, minibatches):
+        self.network.eval()
+        features = torch.cat([self.featurizer(xi) for xi, _ in minibatches])
+
+        # In ResNet we don't have access to the Flatten as a Layer as it is used inplace in the forward pass, hence revert it here
+        if self.featurizer_name == "ResNet":
+            features = features.view(features.shape[0], self.featurizer.n_outputs, 7, 7)
+
+        targets = torch.cat([yi for _,yi in minibatches])
+
+        # detach features to disable gradient flow into the featurizer
+        features_detached = features.clone().detach()
+        features_detached.requires_grad = True
+
+        # Predict
+        output = self.latent_predict(features_detached)
+        num_samples = features_detached.shape[0]
+        num_channels = features_detached.shape[1]
+        H = features_detached.shape[2]
+        HW = features_detached.shape[2] * features_detached.shape[3]
+
+        # Create onehot targets for batch
+        one_hots = self.create_onehots(num_samples, targets)
+
+        # calculate dot product elem_wise between output and one-hot target
+        elem_wise = torch.sum(output * one_hots)
+
+        # calculate gradient of elem_wise wrt feature_detached
+        self.optimizer.zero_grad()
+        elem_wise.backward()
+
+        # Channel & Spatial means
+        grad_val = features_detached.grad.clone().detach()
+        channel_mean = torch.mean(grad_val.view(num_samples, num_channels, -1), dim=2)
+        spatial_mean = torch.mean(grad_val, dim=1).view(num_samples, HW) 
+        self.optimizer.zero_grad()
+
+        # Choose either spatial or channel. Spatial doesn't make sense for architectures which do avgpooling afterwards, but it would make sense for e.g. AlexNet
+        if self.featurizer_name in ["ResNet", "MNIST_CNN"]:
+            choose_spatial = False
+        else:
+            choose_spatial = random.choice([True, False])
+
+        if choose_spatial:
+            mask = self.construct_mask(spatial_mean, num_samples, HW)
+            mask = mask.view(num_samples, 1, H, H)
+
+        else:
+            channel_vector = self.construct_mask(channel_mean, num_samples, num_channels)
+            mask = channel_vector.view(num_samples, num_channels, 1, 1)
+
+        # Drop the mask for certain samples inside each batch
+        class_prob_before = F.softmax(output, dim=1)
+        features_detached_masked = features_detached * mask
+        output_masked = self.latent_predict(features_detached_masked)
+        class_prob_after = F.softmax(output_masked, dim=1)
+
+        before_vector = torch.sum(one_hots * class_prob_before, dim=1)
+        after_vector = torch.sum(one_hots * class_prob_after, dim=1)
+        change = before_vector - after_vector  
+        change = torch.where(change > 0, change, torch.zeros(change.shape).cuda())
+        threshold_value = torch.sort(change, dim=0, descending=True)[0][int(num_samples * self.b_drop_factor)]
+        drop_indeces = change.gt(threshold_value)
+        mask[~drop_indeces.long(), :] = 1
+
+        # Apply the mask on the non-detached features
+        self.train()
+        mask.requires_grad = True
+        features = features * mask
+
+        # calculate loss between prediction and target
+        output_final = self.latent_predict(features)
+        loss = F.cross_entropy(output_final, targets)
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+
+        return {'loss': loss.item()}
+
+    def latent_predict(self, x):
+        x = self.avgpool(x)
+        x = self.flatten(x)
+        return self.classifier(x)
+
+    def predict(self, x):
+        features = self.featurizer(x)
+        if self.featurizer_name == "ResNet":
+            features = features.view(features.shape[0], self.featurizer.n_outputs, 7, 7)
+        return self.latent_predict(features)

--- a/domainbed/algorithms.py
+++ b/domainbed/algorithms.py
@@ -77,8 +77,6 @@ class ERM(Algorithm):
     def update(self, minibatches):
         all_x = torch.cat([x for x,y in minibatches])
         all_y = torch.cat([y for x,y in minibatches])
-        print(all_x.shape)
-        print(all_y.shape)
         loss = F.cross_entropy(self.predict(all_x), all_y)
 
         self.optimizer.zero_grad()
@@ -743,7 +741,7 @@ class RSC(ERM):
             Delete the Average Pooling and use features after bn3
             SqueezeLastTwo is accessible as a Layer so we can delete it and replace it through Identity, serves as our flatten operation later
 
-           Disclaimer: Apparently this algorithm doesn't work very well for the MNIST datasets with the current architecture
+           Disclaimer: Apparently this algorithm doesn't work very well for the MNIST datasets with the current architecture, probably would require more fine-tuning
         """
 
         if self.featurizer_name == "ResNet":

--- a/domainbed/hparams_registry.py
+++ b/domainbed/hparams_registry.py
@@ -55,21 +55,27 @@ def _hparams(algorithm, dataset, random_state):
 
     hparams['resnet_dropout'] = (0., random_state.choice([0., 0.1, 0.5]))
 
-    if algorithm == "SagNet":
-        hparams['sag_w_adv'] = (0.1, 10 ** random_state.uniform(-2, 1))
+    if algorithm == "RSC":
+        hparams['rsc_f_drop_factor'] = (1/3, random_state.uniform(0,0.5)) # Feature drop factor
+        hparams['rsc_b_drop_factor'] = (1/3, random_state.uniform(0, 0.5)) # Batch drop factor
+        hparams['resnet_dropout'] = (0, 0)
+    elif algorithm == "SagNet":
+        hparams['resnet_dropout'] = (.5, random_state.choice([0., 0.1, 0.5]))
+        hparams['sag_w_adv'] = (0.1, 10**random_state.uniform(-2, 1))
     elif algorithm == "IRM":
-        hparams['irm_lambda'] = (1e2, 10 ** random_state.uniform(-1, 5))
-        hparams['irm_penalty_anneal_iters'] = (500, int(10 ** random_state.uniform(0, 4)))
+        hparams['irm_lambda'] = (1e2, 10**random_state.uniform(-1, 5))
+        hparams['irm_penalty_anneal_iters'] = (500, int(10**random_state.uniform(0, 4)))
     elif algorithm == "Mixup":
-        hparams['mixup_alpha'] = (0.2, 10 ** random_state.uniform(-1, -1))
+        hparams['mixup_alpha'] = (0.2, 10**random_state.uniform(-1, -1))
     elif algorithm == "GroupDRO":
-        hparams['groupdro_eta'] = (1e-2, 10 ** random_state.uniform(-3, -1))
+        hparams['groupdro_eta'] = (1e-2, 10**random_state.uniform(-3, -1))
     elif algorithm == "MMD":
-        hparams['mmd_gamma'] = (1., 10 ** random_state.uniform(-1, 1))
+        hparams['mmd_gamma'] = (1., 10**random_state.uniform(-1, 1))
     elif algorithm == "MLDG":
-        hparams['mldg_beta'] = (1., 10 ** random_state.uniform(-1, 1))
+        hparams['mldg_beta'] = (1., 10**random_state.uniform(-1, 1))
     elif algorithm == "MTL":
         hparams['mtl_ema'] = (.99, random_state.choice([0.5, 0.9, 0.99, 1.]))
+
 
     # TODO clean this up
     hparams.update({a:(b,c) for a,b,c in [

--- a/domainbed/hparams_registry.py
+++ b/domainbed/hparams_registry.py
@@ -14,6 +14,8 @@ def _hparams(algorithm, dataset, random_state):
     
     hparams['data_augmentation'] = (True, True)
     hparams['resnet18'] = (False, False)
+    hparams['resnet_dropout'] = (0., random_state.choice([0., 0.1, 0.5]))
+    hparams['class_balanced'] = (False, False)
 
     if dataset not in SMALL_IMAGES:
         hparams['lr'] = (5e-5, 10**random_state.uniform(-5, -3.5))
@@ -32,7 +34,6 @@ def _hparams(algorithm, dataset, random_state):
     else:
         hparams['weight_decay'] = (0., 10**random_state.uniform(-6, -2))
 
-    hparams['class_balanced'] = (False, False)
 
     if algorithm in ['DANN', 'CDANN']:
         if dataset not in SMALL_IMAGES:
@@ -52,10 +53,10 @@ def _hparams(algorithm, dataset, random_state):
         hparams['d_steps_per_g_step'] = (1, int(2**random_state.uniform(0, 3)))
         hparams['grad_penalty'] = (0., 10**random_state.uniform(-2, 1))
         hparams['beta1'] = (0.5, random_state.choice([0., 0.5]))
-
-    hparams['resnet_dropout'] = (0., random_state.choice([0., 0.1, 0.5]))
-
-    if algorithm == "RSC":
+        hparams['mlp_width'] = (256, int(2 ** random_state.uniform(6, 10)))
+        hparams['mlp_depth'] = (3, int(random_state.choice([3, 4, 5])))
+        hparams['mlp_dropout'] = (0., random_state.choice([0., 0.1, 0.5]))
+    elif algorithm == "RSC":
         hparams['rsc_f_drop_factor'] = (1/3, random_state.uniform(0,0.5)) # Feature drop factor
         hparams['rsc_b_drop_factor'] = (1/3, random_state.uniform(0, 0.5)) # Batch drop factor
         hparams['resnet_dropout'] = (0, 0)
@@ -76,14 +77,6 @@ def _hparams(algorithm, dataset, random_state):
     elif algorithm == "MTL":
         hparams['mtl_ema'] = (.99, random_state.choice([0.5, 0.9, 0.99, 1.]))
 
-
-    # TODO clean this up
-    hparams.update({a:(b,c) for a,b,c in [
-        # MLP
-        ('mlp_width', 256, int(2**random_state.uniform(6, 10))),
-        ('mlp_depth', 3, int(random_state.choice([3,4,5])) ),
-        ('mlp_dropout', 0., random_state.choice([0., 0.1, 0.5])),
-    ]})
     return hparams
 
 def default_hparams(algorithm, dataset):

--- a/domainbed/hparams_registry.py
+++ b/domainbed/hparams_registry.py
@@ -55,26 +55,28 @@ def _hparams(algorithm, dataset, random_state):
 
     hparams['resnet_dropout'] = (0., random_state.choice([0., 0.1, 0.5]))
 
+    if algorithm == "SagNet":
+        hparams['sag_w_adv'] = (0.1, 10 ** random_state.uniform(-2, 1))
+    elif algorithm == "IRM":
+        hparams['irm_lambda'] = (1e2, 10 ** random_state.uniform(-1, 5))
+        hparams['irm_penalty_anneal_iters'] = (500, int(10 ** random_state.uniform(0, 4)))
+    elif algorithm == "Mixup":
+        hparams['mixup_alpha'] = (0.2, 10 ** random_state.uniform(-1, -1))
+    elif algorithm == "GroupDRO":
+        hparams['groupdro_eta'] = (1e-2, 10 ** random_state.uniform(-3, -1))
+    elif algorithm == "MMD":
+        hparams['mmd_gamma'] = (1., 10 ** random_state.uniform(-1, 1))
+    elif algorithm == "MLDG":
+        hparams['mldg_beta'] = (1., 10 ** random_state.uniform(-1, 1))
+    elif algorithm == "MTL":
+        hparams['mtl_ema'] = (.99, random_state.choice([0.5, 0.9, 0.99, 1.]))
+
     # TODO clean this up
     hparams.update({a:(b,c) for a,b,c in [
-        # IRM
-        ('irm_lambda', 1e2, 10**random_state.uniform(-1, 5)),
-        ('irm_penalty_anneal_iters', 500, int(10**random_state.uniform(0, 4))),
-        # Mixup
-        ('mixup_alpha', 0.2, 10**random_state.uniform(-1, -1)),
-        # GroupDRO
-        ('groupdro_eta', 1e-2, 10**random_state.uniform(-3, -1)),
-        # MMD
-        ('mmd_gamma', 1., 10**random_state.uniform(-1, 1)),
         # MLP
         ('mlp_width', 256, int(2**random_state.uniform(6, 10))),
         ('mlp_depth', 3, int(random_state.choice([3,4,5])) ),
         ('mlp_dropout', 0., random_state.choice([0., 0.1, 0.5])),
-        # MLDG
-        ('mldg_beta', 1., 10**random_state.uniform(-1, 1)),
-        ('mtl_ema', .99, random_state.choice([0.5, 0.9, 0.99, 1.])),
-        # SagNets
-        ('sag_w_adv', 0.1, 10**random_state.uniform(-2, 1)),
     ]})
     return hparams
 

--- a/domainbed/networks.py
+++ b/domainbed/networks.py
@@ -44,7 +44,6 @@ class MLP(nn.Module):
             for _ in range(hparams['mlp_depth']-2)])
         self.output = nn.Linear(hparams['mlp_width'], n_outputs)
         self.n_outputs = n_outputs
-        self.name = "MLP"
 
     def forward(self, x):
         x = self.input(x)

--- a/domainbed/networks.py
+++ b/domainbed/networks.py
@@ -5,13 +5,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torchvision.models
 
-from torch.utils import model_zoo
-from torchvision.models.resnet import BasicBlock, model_urls, Bottleneck
-from torch.autograd import Variable
-import numpy.random as npr
-import numpy as np
-import random
-
 from domainbed.lib import misc
 from domainbed.lib import wide_resnet
 

--- a/domainbed/networks.py
+++ b/domainbed/networks.py
@@ -53,7 +53,7 @@ class MLP(nn.Module):
             x = hidden(x)
             x = self.dropout(x)
             x = F.relu(x)
-            x = self.output(x)
+        x = self.output(x)
         return x
 
 class ResNet(torch.nn.Module):
@@ -89,8 +89,7 @@ class ResNet(torch.nn.Module):
 
     def forward(self, x):
         """Encode x into a feature vector of size n_outputs."""
-        x = self.dropout(self.network(x))
-        return x
+        return self.dropout(self.network(x))
 
     def train(self, mode=True):
         """


### PR DESCRIPTION
This PR implements the following features:

- Representation Self-Challenging (RSC) from: https://arxiv.org/abs/2007.02454
- Cleanup algorithm-specific hyperparameters in hyperparameter registry so they don't flood the console by default
- Adapted `MNIST_CNN` forward pass to use `AdaptiveAvgpool2d` instead of mean, this allows for more flexible usage in algorithms and feels more clean

You might also want to delete the MLP parts in `networks.py`  and `hparams_registry.py` as well since I think MLP was only added for Debug datasets that don't get used anymore?