### PR TITLE
Change training loop to proper epochs and add lr schedules

### DIFF
--- a/domainbed/algorithms.py
+++ b/domainbed/algorithms.py
@@ -26,6 +26,7 @@ ALGORITHMS = [
     'MTL', 
     'SagNet',
     'ARM',
+    'VREx',
     'RSC'
 ]
 
@@ -262,6 +263,52 @@ class IRM(ERM):
         self.update_count += 1
         return {'loss': loss.item(), 'nll': nll.item(),
             'penalty': penalty.item()}
+
+
+class VREx(ERM):
+    """V-REx algorithm from http://arxiv.org/abs/2003.00688"""
+    def __init__(self, input_shape, num_classes, num_domains, hparams):
+        super(VREx, self).__init__(input_shape, num_classes, num_domains,
+                                  hparams)
+        self.register_buffer('update_count', torch.tensor([0]))
+
+    def update(self, minibatches):
+        if self.update_count >= self.hparams["vrex_penalty_anneal_iters"]:
+            penalty_weight = self.hparams["vrex_lambda"]
+        else:
+            penalty_weight = 1.0
+
+        nll = 0.
+
+        all_x = torch.cat([x for x, y in minibatches])
+        all_logits = self.network(all_x)
+        all_logits_idx = 0
+        losses = torch.zeros(len(minibatches))
+        for i, (x, y) in enumerate(minibatches):
+            logits = all_logits[all_logits_idx:all_logits_idx + x.shape[0]]
+            all_logits_idx += x.shape[0]
+            nll = F.cross_entropy(logits, y)
+            losses[i] = nll
+
+        mean = losses.mean()
+        penalty = ((losses - mean) ** 2).mean()
+        loss = mean + penalty_weight * penalty
+
+        if self.update_count == self.hparams['vrex_penalty_anneal_iters']:
+            # Reset Adam (like IRM), because it doesn't like the sharp jump in
+            # gradient magnitudes that happens at this step.
+            self.optimizer = torch.optim.Adam(
+                self.network.parameters(),
+                lr=self.hparams["lr"],
+                weight_decay=self.hparams['weight_decay'])
+
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+
+        self.update_count += 1
+        return {'loss': loss.item(), 'nll': nll.item(),
+                'penalty': penalty.item()}
 
 
 class Mixup(ERM):

--- a/domainbed/datasets.py
+++ b/domainbed/datasets.py
@@ -55,8 +55,8 @@ def get_dataset_class(dataset_name):
     return globals()[dataset_name]
 
 class MultipleDomainDataset:
-    N_STEPS = 5001 
-    CHECKPOINT_FREQ = 100
+    EPOCHS = 150
+    CHECKPOINT_FREQ = 10
     N_WORKERS = 8
 
 class Debug(MultipleDomainDataset):
@@ -239,35 +239,35 @@ class MultipleEnvironmentImageFolder(MultipleDomainDataset):
         return len(self.datasets)
 
 class VLCS(MultipleEnvironmentImageFolder):
-    CHECKPOINT_FREQ = 300
+    CHECKPOINT_FREQ = 10
     ENVIRONMENT_NAMES = ["C", "L", "S", "V"]
     def __init__(self, root, test_envs, hparams):
         self.dir = os.path.join(root, "VLCS/")
         super().__init__(self.dir, test_envs, hparams['data_augmentation'], hparams)
 
 class PACS(MultipleEnvironmentImageFolder):
-    CHECKPOINT_FREQ = 300
+    CHECKPOINT_FREQ = 10
     ENVIRONMENT_NAMES = ["A", "C", "P", "S"]
     def __init__(self, root, test_envs, hparams):
         self.dir = os.path.join(root, "PACS/")
         super().__init__(self.dir, test_envs, hparams['data_augmentation'], hparams)
 
 class DomainNet(MultipleEnvironmentImageFolder):
-    CHECKPOINT_FREQ = 1000
+    CHECKPOINT_FREQ = 10
     ENVIRONMENT_NAMES = ["clip", "info", "paint", "quick", "real", "sketch"]
     def __init__(self, root, test_envs, hparams):
         self.dir = os.path.join(root, "domain_net/")
         super().__init__(self.dir, test_envs, hparams['data_augmentation'], hparams)
 
 class OfficeHome(MultipleEnvironmentImageFolder):
-    CHECKPOINT_FREQ = 300
+    CHECKPOINT_FREQ = 10
     ENVIRONMENT_NAMES = ["A", "C", "P", "R"]
     def __init__(self, root, test_envs, hparams):
         self.dir = os.path.join(root, "office_home/")
         super().__init__(self.dir, test_envs, hparams['data_augmentation'], hparams)
 
 class TerraIncognita(MultipleEnvironmentImageFolder):
-    CHECKPOINT_FREQ = 300
+    CHECKPOINT_FREQ = 10
     ENVIRONMENT_NAMES = ["L100", "L38", "L43", "L46"]
     def __init__(self, root, test_envs, hparams):
         self.dir = os.path.join(root, "terra_incognita/")

--- a/domainbed/hparams_registry.py
+++ b/domainbed/hparams_registry.py
@@ -15,6 +15,7 @@ def _hparams(algorithm, dataset, random_state):
     hparams['resnet18'] = (False, False)
     hparams['resnet_dropout'] = (0., random_state.choice([0., 0.1, 0.5]))
     hparams['class_balanced'] = (False, False)
+    hparams['lr_scheduled'] = (False, False)
 
     if dataset not in SMALL_IMAGES:
         hparams['lr'] = (5e-5, 10**random_state.uniform(-5, -3.5))

--- a/domainbed/model_selection.py
+++ b/domainbed/model_selection.py
@@ -54,7 +54,7 @@ class OracleSelectionMethod(SelectionMethod):
         test_env = run_records[0]['args']['test_envs'][0]
         test_out_acc_key = 'env{}_out_acc'.format(test_env)
         test_in_acc_key = 'env{}_in_acc'.format(test_env)
-        chosen_record = run_records.sorted(lambda r: r['step'])[-1]
+        chosen_record = run_records.sorted(lambda r: r['epoch'])[-1]
         return {
             'val_acc':  chosen_record[test_out_acc_key],
             'test_acc': chosen_record[test_in_acc_key]
@@ -120,7 +120,7 @@ class LeaveOneOutSelectionMethod(SelectionMethod):
 
     @classmethod
     def run_acc(self, records):
-        step_accs = records.group('step').map(lambda step, step_records:
+        step_accs = records.group('epoch').map(lambda step, step_records:
             self._step_acc(step_records)
         ).filter_not_none()
         if len(step_accs):

--- a/domainbed/optimizers.py
+++ b/domainbed/optimizers.py
@@ -1,0 +1,19 @@
+import torch
+
+class GenericAdam():
+    def __init__(self, parameters, hparams):
+        self.optimizer = torch.optim.Adam(
+            parameters,
+            lr=hparams["lr"],
+            weight_decay=hparams['weight_decay']
+        )
+
+    """
+    Returns the scheduler which is intended for the current algorithm.
+    """
+    def get_scheduler(self, algorithm):
+        if algorithm == "RSC":
+            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(self.optimizer, patience=3, threshold=0.0001, verbose=True)
+        else:
+            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(self.optimizer, patience=3, threshold=0.0001, verbose=True)
+        return scheduler

--- a/domainbed/optimizers.py
+++ b/domainbed/optimizers.py
@@ -13,7 +13,7 @@ class GenericAdam():
     """
     def get_scheduler(self, algorithm):
         if algorithm == "RSC":
-            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(self.optimizer, patience=3, threshold=0.0001, verbose=True)
+            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(self.optimizer, patience=5, threshold=0.0001)
         else:
-            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(self.optimizer, patience=3, threshold=0.0001, verbose=True)
+            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(self.optimizer, patience=5, threshold=0.00005)
         return scheduler

--- a/domainbed/scripts/train.py
+++ b/domainbed/scripts/train.py
@@ -128,7 +128,6 @@ if __name__ == "__main__":
         algorithm.load_state_dict(algorithm_dict)
 
     algorithm.to(device)
-    #algorithm = torch.nn.DataParallel(algorithm, device_ids=range(torch.cuda.device_count())) # Data Parallelism
 
     train_minibatches_iterator = zip(*train_loaders)
     checkpoint_vals = collections.defaultdict(lambda: [])


### PR DESCRIPTION
This PR implements the following features:

- Change the training step loop to a proper epoch + step loop as mentioned here: #17 
- Add learning rate schedules as mentioned here: #15 
- Print Epoch count instead of step count to the console
- Print the current learning rate for the checkpoint to the console

There are some hyperparameter choices regarding the learning rate schedules which are set to some defaults here. They might need some fine-tuning. The new hyperparameter `lr_scheduled` is set to `False` by default and when sampled. Also: The new epochs for the datasets might need to be fine-tuned, I don't know what was the value before and just set them to some value for now.

There are some design choices which you might want to verify i.e. the new `optimizers.py` and keeping the `lr` printed even when `lr_scheduled` is set to `False` (went for this option for consistency in the output).

I haven't checked how to adapt all the other scripts to this change, there might be more to change.

Since I'm on vacation starting from tomorrow, these changes are only slightly tested manually. As they entail major changes to the training loop, please verify carefully, e.g. the usage of  `steps_per_epoch`!