### PR TITLE
Add Fishr: Invariant Gradient Variances for Out-of-distribution Generalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The [currently available algorithms](domainbed/algorithms.py) are:
 * Gradient Matching for Domain Generalization (Fish, [Shi et al., 2021](https://arxiv.org/pdf/2104.09937.pdf))
 * Self-supervised Contrastive Regularization (SelfReg, [Kim et al., 2021](https://arxiv.org/abs/2104.09841))
 * Smoothed-AND mask (SAND-mask, [Shahtalebi et al., 2021](https://arxiv.org/abs/2106.02266))
+* Invariant Gradient Variances for Out-of-distribution Generalization (Fishr, [Rame et al., 2021](https://arxiv.org/abs/2109.02934))
 
 Send us a PR to add your algorithm! Our implementations use ResNet50 / ResNet18 networks ([He et al., 2015](https://arxiv.org/abs/1512.03385)) and the hyper-parameter grids [described here](domainbed/hparams_registry.py).
 

--- a/domainbed/algorithms.py
+++ b/domainbed/algorithms.py
@@ -8,10 +8,18 @@ from torch.autograd import Variable
 
 import copy
 import numpy as np
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
+try:
+    from backpack import backpack, extend
+    from backpack.extensions import BatchGrad
+except:
+    backpack = None
 
 from domainbed import networks
-from domainbed.lib.misc import random_pairs_of_minibatches, ParamDict
+from domainbed.lib.misc import (
+    random_pairs_of_minibatches, ParamDict, MovingAverage, l2_between_dicts
+)
+
 
 ALGORITHMS = [
     'ERM',
@@ -33,7 +41,8 @@ ALGORITHMS = [
     'ANDMask',
     'SANDMask',    # SAND-mask
     'IGA',
-    'SelfReg'
+    'SelfReg',
+    "Fishr"
 ]
 
 def get_algorithm_class(algorithm_name):
@@ -1170,4 +1179,136 @@ class SANDMask(ERM):
             mask_t = (mask.sum() / mask.numel())
             param.grad = mask * avg_grad
             param.grad *= (1. / (1e-10 + mask_t))
+
+
+
+class Fishr(Algorithm):
+    "Invariant Gradients variances for Out-of-distribution Generalization"
+
+    def __init__(self, input_shape, num_classes, num_domains, hparams):
+        assert backpack is not None, "Install backpack with: 'pip install backpack-for-pytorch==1.3.0'"
+        super(Fishr, self).__init__(input_shape, num_classes, num_domains, hparams)
+        self.num_domains = num_domains
+
+        self.featurizer = networks.Featurizer(input_shape, self.hparams)
+        self.classifier = extend(
+            networks.Classifier(
+                self.featurizer.n_outputs,
+                num_classes,
+                self.hparams['nonlinear_classifier'],
+            )
+        )
+        self.network = nn.Sequential(self.featurizer, self.classifier)
+
+        self.register_buffer("update_count", torch.tensor([0]))
+        self.bce_extended = extend(nn.CrossEntropyLoss(reduction='none'))
+        self.ema_per_domain = [
+            MovingAverage(ema=self.hparams["ema"], oneminusema_correction=True)
+            for _ in range(self.num_domains)
+        ]
+        self._init_optimizer()
+
+    def _init_optimizer(self):
+        self.optimizer = torch.optim.Adam(
+            list(self.featurizer.parameters()) + list(self.classifier.parameters()),
+            lr=self.hparams["lr"],
+            weight_decay=self.hparams["weight_decay"],
+        )
+
+    def update(self, minibatches, unlabeled=False):
+        assert len(minibatches) == self.num_domains
+        all_x = torch.cat([x for x, y in minibatches])
+        all_y = torch.cat([y for x, y in minibatches])
+        len_minibatches = [x.shape[0] for x, y in minibatches]
+
+        all_z = self.featurizer(all_x)
+        all_logits = self.classifier(all_z)
+
+        penalty = self.compute_fishr_penalty(all_logits, all_y, len_minibatches)
+        all_nll = F.cross_entropy(all_logits, all_y)
+
+        penalty_weight = 0
+        if self.update_count >= self.hparams["penalty_anneal_iters"]:
+            penalty_weight = self.hparams["lambda"]
+            if self.update_count == self.hparams["penalty_anneal_iters"] != 0:
+                # Reset Adam as in IRM or V-REx, because it may not like the sharp jump in
+                # gradient magnitudes that happens at this step.
+                self._init_optimizer()
+        self.update_count += 1
+
+        objective = all_nll + penalty_weight * penalty
+        self.optimizer.zero_grad()
+        objective.backward()
+        self.optimizer.step()
+
+        return {'loss': objective.item(), 'nll': all_nll.item(), 'penalty': penalty.item()}
+
+    def compute_fishr_penalty(self, all_logits, all_y, len_minibatches):
+        dict_grads = self._get_grads(all_logits, all_y)
+        grads_var_per_domain = self._get_grads_var_per_domain(dict_grads, len_minibatches)
+        return self._compute_distance_grads_var(grads_var_per_domain)
+
+    def _get_grads(self, logits, y):
+        self.optimizer.zero_grad()
+        loss = self.bce_extended(logits, y).sum()
+        with backpack(BatchGrad()):
+            loss.backward(
+                inputs=list(self.classifier.parameters()), retain_graph=True, create_graph=True
+            )
+
+        # compute individual grads for all samples across all domains simultaneously
+        dict_grads = OrderedDict(
+            [
+                (name, weights.grad_batch.clone().view(weights.grad_batch.size(0), -1))
+                for name, weights in self.classifier.named_parameters()
+            ]
+        )
+        return dict_grads
+
+    def _get_grads_var_per_domain(self, dict_grads, len_minibatches):
+        # grads var per domain
+        grads_var_per_domain = [{} for _ in range(self.num_domains)]
+        for name, _grads in dict_grads.items():
+            all_idx = 0
+            for domain_id, bsize in enumerate(len_minibatches):
+                env_grads = _grads[all_idx:all_idx + bsize]
+                all_idx += bsize
+                env_mean = env_grads.mean(dim=0, keepdim=True)
+                env_grads_centered = env_grads - env_mean
+                grads_var_per_domain[domain_id][name] = (env_grads_centered).pow(2).mean(dim=0)
+
+        # moving average
+        for domain_id in range(self.num_domains):
+            grads_var_per_domain[domain_id] = self.ema_per_domain[domain_id].update(
+                grads_var_per_domain[domain_id]
+            )
+
+        return grads_var_per_domain
+
+    def _compute_distance_grads_var(self, grads_var_per_domain):
+
+        # compute gradient variances averaged across domains
+        grads_var = OrderedDict(
+            [
+                (
+                    name,
+                    torch.stack(
+                        [
+                            grads_var_per_domain[domain_id][name]
+                            for domain_id in range(self.num_domains)
+                        ],
+                        dim=0
+                    ).mean(dim=0)
+                )
+                for name in grads_var_per_domain[0].keys()
+            ]
+        )
+
+        penalty = 0
+        for domain_id in range(self.num_domains):
+            penalty += l2_between_dicts(grads_var_per_domain[domain_id], grads_var)
+        return penalty / self.num_domains
+
+    def predict(self, x):
+        return self.network(x)
 

--- a/domainbed/hparams_registry.py
+++ b/domainbed/hparams_registry.py
@@ -1,5 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-
 import numpy as np
 from domainbed.lib import misc
 
@@ -96,6 +95,11 @@ def _hparams(algorithm, dataset, random_seed):
     elif algorithm == "SANDMask":
         _hparam('tau', 1.0, lambda r: r.uniform(0.0, 1.))
         _hparam('k', 1e+1, lambda r: 10**r.uniform(-3, 5))
+
+    elif algorithm == "Fishr":
+        _hparam('lambda', 1000., lambda r: 10**r.uniform(1., 4.))
+        _hparam('penalty_anneal_iters', 1500, lambda r: int(r.uniform(0., 5000.)))
+        _hparam('ema', 0.95, lambda r: r.uniform(0.90, 0.99))
 
     # Dataset-and-algorithm-specific hparam definitions. Each block of code
     # below corresponds to exactly one hparam. Avoid nested conditionals.


### PR DESCRIPTION
We propose a new regularization - named Fishr - that enforces domain invariance in the space of the gradients of the loss function: specifically, it tackles the domain-level variances of gradients across the training domains.
Compared to existing methods on DomainBed, Fishr performs best in the 'Oracle' model selection and third in the 'Training' model selection. Moreover, Fishr performs consistently better than ERM.
The paper is on [arXiv](https://arxiv.org/abs/2109.02934).