### PR TITLE
Modified a typo, IB_IRM and IB_ERM

### DIFF
--- a/domainbed/algorithms.py
+++ b/domainbed/algorithms.py
@@ -44,8 +44,8 @@ ALGORITHMS = [
     'SelfReg',
     "Fishr",
     'TRM',
-    'IB-ERM',
-    'IB-IRM',
+    'IB_ERM',
+    'IB_IRM',
 ]
 
 def get_algorithm_class(algorithm_name):


### PR DESCRIPTION
In global  "Algorithms" variable, the script couldn't identify IB-IRM and IB-ERM.
Line 47 and 48