### PR TITLE
fixed both bug in TRM.update & inconsistencies in some signatures

### DIFF
--- a/domainbed/algorithms.py
+++ b/domainbed/algorithms.py
@@ -1000,7 +1000,7 @@ class IGA(ERM):
     def __init__(self, in_features, num_classes, num_domains, hparams):
         super(IGA, self).__init__(in_features, num_classes, num_domains, hparams)
 
-    def update(self, minibatches, unlabeled=False):
+    def update(self, minibatches, unlabeled=None):
         total_loss = 0
         grads = []
         for i, (x, y) in enumerate(minibatches):
@@ -1220,7 +1220,7 @@ class Fishr(Algorithm):
             weight_decay=self.hparams["weight_decay"],
         )
 
-    def update(self, minibatches, unlabeled=False):
+    def update(self, minibatches, unlabeled=None):
         assert len(minibatches) == self.num_domains
         all_x = torch.cat([x for x, y in minibatches])
         all_y = torch.cat([y for x, y in minibatches])
@@ -1384,7 +1384,7 @@ class TRM(Algorithm):
         model.train()
         return h_estimate.detach()
 
-    def update(self, minibatches):
+    def update(self, minibatches, unlabeled=None):
 
         loss_swap = 0.0
         trm = 0.0


### PR DESCRIPTION
The update function for TRM is missing an argument for unlabeled data. This causes a failure when L217 in [scripts/train.py](https://github.com/facebookresearch/DomainBed/blob/7b766660710bb5f9481904230481139733cc0fc9/domainbed/scripts/train.py#L217) is executed, specifically the following function call: `algorithm.update(minibatches_device, uda_device)`.

Additionally, the default value for `unlabeled` in a couple of classes was set to `False` rather than `None` as is the case with all others.