### PR TITLE
add method: Uniform Risk Minimization (URM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The [currently available algorithms](domainbed/algorithms.py) are:
 * Domain Generalisation via Risk Distribution Matching (RDM, [Nguyen et al., 2024](https://arxiv.org/abs/2310.18598)), contributed by [@nktoan](https://github.com/nktoan), [authors' contact email](mailto:ktoan271199@gmail.com)
 * ADRMX: Additive Disentanglement of Domain Features with Remix Loss (ADRMX, [Demirel et al., 2023](https://arxiv.org/abs/2308.06624)), contributed by [@berkerdemirel](https://github.com/berkerdemirel)
 * ERM++: An Improved Baseline for Domain Generalization( ERM++, [Teterwak et. al. 2023](https://arxiv.org/abs/2304.01973), contributed by [@piotr-teterwak](https://cs-people.bu.edu/piotrt/).
-* Uniform Risk Minimization (URM) from Uniformly Distributed Feature Representations for Fair and Robust Learning ([Krishnamachari et al., 2024](https://openreview.net/forum?id=PgLbS5yp8n))
+* Uniform Risk Minimization (URM) from Uniformly Distributed Feature Representations for Fair and Robust Learning ([Krishnamachari et al., 2024](https://openreview.net/forum?id=PgLbS5yp8n)), contributed by [@kiranchari](https://github.com/kiranchari), [authors' contact email](mailto:kirankchari@gmail.com)
 
 Send us a PR to add your algorithm! Our implementations use ResNet50 / ResNet18 networks ([He et al., 2015](https://arxiv.org/abs/1512.03385)) and the hyper-parameter grids [described here](domainbed/hparams_registry.py).
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The [currently available algorithms](domainbed/algorithms.py) are:
 * Domain Generalisation via Risk Distribution Matching (RDM, [Nguyen et al., 2024](https://arxiv.org/abs/2310.18598)), contributed by [@nktoan](https://github.com/nktoan), [authors' contact email](mailto:ktoan271199@gmail.com)
 * ADRMX: Additive Disentanglement of Domain Features with Remix Loss (ADRMX, [Demirel et al., 2023](https://arxiv.org/abs/2308.06624)), contributed by [@berkerdemirel](https://github.com/berkerdemirel)
 * ERM++: An Improved Baseline for Domain Generalization( ERM++, [Teterwak et. al. 2023](https://arxiv.org/abs/2304.01973), contributed by [@piotr-teterwak](https://cs-people.bu.edu/piotrt/).
+* Uniform Risk Minimization (URM) from Uniformly Distributed Feature Representations for Fair and Robust Learning ([Krishnamachari et al., 2024](https://openreview.net/forum?id=PgLbS5yp8n))
 
 Send us a PR to add your algorithm! Our implementations use ResNet50 / ResNet18 networks ([He et al., 2015](https://arxiv.org/abs/1512.03385)) and the hyper-parameter grids [described here](domainbed/hparams_registry.py).
 

--- a/domainbed/algorithms.py
+++ b/domainbed/algorithms.py
@@ -56,6 +56,7 @@ ALGORITHMS = [
     'EQRM',
     'RDM',
     'ADRMX',
+    'URM',
 ]
 
 def get_algorithm_class(algorithm_name):
@@ -231,6 +232,200 @@ class ERMPlusPlus(Algorithm,ErmPlusPlusMovingAvg):
                      schedule = schedule[1:]
              return schedule
 
+class URM(ERM):
+    """
+    Implementation of Uniform Risk Minimization, as seen in Uniformly Distributed Feature Representations for
+    Fair and Robust Learning. TMLR 2024 (https://openreview.net/forum?id=PgLbS5yp8n)
+    """
+    def __init__(self, input_shape, num_classes, num_domains, hparams):
+        ERM.__init__(self, input_shape, num_classes, num_domains, hparams)
+
+        # setup discriminator model for URM adversarial training
+        self._setup_adversarial_net()
+
+        self.loss = torch.nn.CrossEntropyLoss(reduction="none")
+
+    def _modify_generator_output(self):
+        print('--> Modifying encoder output:', self.hparams['urm_generator_output'])
+        
+        from domainbed.lib import wide_resnet
+        assert type(self.featurizer) in [networks.MLP, networks.MNIST_CNN, wide_resnet.Wide_ResNet, networks.ResNet]
+
+        if self.hparams['urm_generator_output'] == 'tanh':
+            self.featurizer.activation = nn.Tanh()
+
+        elif self.hparams['urm_generator_output'] == 'sigmoid':
+            self.featurizer.activation = nn.Sigmoid()
+        
+        elif self.hparams['urm_generator_output'] == 'identity':
+            self.featurizer.activation = nn.Identity()
+
+        elif self.hparams['urm_generator_output'] == 'relu':
+            self.featurizer.activation = nn.ReLU()
+
+        else:
+            raise Exception('unrecognized output activation: %s' % self.hparams['urm_generator_output'])
+
+    def _setup_adversarial_net(self):
+        print('--> Initializing discriminator <--')        
+        self.discriminator = self._init_discriminator()
+        self.discriminator_loss = torch.nn.BCEWithLogitsLoss(reduction="mean") # apply on logit
+
+        # featurizer optimized by self.optimizer only
+        if self.hparams["urm_discriminator_optimizer"] == 'sgd':
+            self.discriminator_opt = torch.optim.SGD(self.discriminator.parameters(), lr=self.hparams['urm_discriminator_lr'], \
+                weight_decay=self.hparams['weight_decay'], momentum=0.9)
+        elif self.hparams["urm_discriminator_optimizer"] == 'adam':
+            self.discriminator_opt = torch.optim.Adam(self.discriminator.parameters(), lr=self.hparams['urm_discriminator_lr'], \
+                weight_decay=self.hparams['weight_decay'])
+        else:
+            raise Exception('%s unimplemented' % self.hparams["urm_discriminator_optimizer"])
+
+        self._modify_generator_output()
+        self.sigmoid = nn.Sigmoid() # to compute discriminator acc.
+            
+    def _init_discriminator(self):
+        """
+        3 hidden layer MLP
+        """
+        model = nn.Sequential()
+        model.add_module("dense1", nn.Linear(self.featurizer.n_outputs, 100))
+        model.add_module("act1", nn.LeakyReLU())
+
+        for _ in range(self.hparams['urm_discriminator_hidden_layers']):            
+            model.add_module("dense%d" % (2+_), nn.Linear(100, 100))
+            model.add_module("act2%d" % (2+_), nn.LeakyReLU())
+
+        model.add_module("output", nn.Linear(100, 1)) 
+        return model
+
+    def _generate_noise(self, feats):
+        """
+        If U is a random variable uniformly distributed on [0, 1), then (b-a)*U + a is uniformly distributed on [a, b).
+        """
+        if self.hparams['urm_generator_output'] == 'tanh':
+            a,b = -1,1
+        elif self.hparams['urm_generator_output'] == 'relu':
+            a,b = 0,1
+        elif self.hparams['urm_generator_output'] == 'sigmoid':
+            a,b = 0,1
+        else:
+            raise Exception('unrecognized output activation: %s' % self.hparams['urm_generator_output'])
+
+        uniform_noise = torch.rand(feats.size(), dtype=feats.dtype, layout=feats.layout, device=feats.device) # U~[0,1]
+        n = ((b-a) * uniform_noise) + a # n ~ [a,b)
+        return n
+
+    def _generate_soft_labels(self, size, device, a ,b):
+        # returns size random numbers in [a,b]
+         uniform_noise = torch.rand(size, device=device) # U~[0,1]
+         return ((b-a) * uniform_noise) + a
+
+    def get_accuracy(self, y_true, y_prob):
+        # y_prob is binary probability
+        assert y_true.ndim == 1 and y_true.size() == y_prob.size()
+        y_prob = y_prob > 0.5
+        return (y_true == y_prob).sum().item() / y_true.size(0)
+
+    def return_feats(self, x):
+        return self.featurizer(x)
+
+    def _update_discriminator(self, x, y, feats):
+        # feats = self.return_feats(x)
+        feats = feats.detach() # don't backbrop through encoder in this step
+        noise = self._generate_noise(feats)
+        
+        noise_logits = self.discriminator(noise) # (N,1)
+        feats_logits = self.discriminator(feats) # (N,1)
+
+        # hard targets
+        hard_true_y = torch.tensor([1] * noise.shape[0], device=noise.device, dtype=noise.dtype) # [1,1...1] noise is true
+        hard_fake_y = torch.tensor([0] * feats.shape[0], device=feats.device, dtype=feats.dtype) # [0,0...0] feats are fake (generated)
+
+        if self.hparams['urm_discriminator_label_smoothing']:
+            # label smoothing in discriminator
+            soft_true_y = self._generate_soft_labels(noise.shape[0], noise.device, 1-self.hparams['urm_discriminator_label_smoothing'], 1.0) # random labels in range
+            soft_fake_y = self._generate_soft_labels(feats.shape[0], feats.device, 0, 0+self.hparams['urm_discriminator_label_smoothing']) # random labels in range
+            true_y = soft_true_y
+            fake_y = soft_fake_y
+        else:
+            true_y = hard_true_y
+            fake_y = hard_fake_y
+
+        noise_loss = self.discriminator_loss(noise_logits.squeeze(1), true_y) # pass logits to BCEWithLogitsLoss
+        feats_loss = self.discriminator_loss(feats_logits.squeeze(1), fake_y) # pass logits to BCEWithLogitsLoss
+
+        d_loss = 1*noise_loss + self.hparams['urm_adv_lambda']*feats_loss
+
+        # update discriminator
+        self.discriminator_opt.zero_grad()
+        d_loss.backward()
+        self.discriminator_opt.step()
+
+    def _compute_loss(self, x, y):
+        feats = self.return_feats(x)
+        ce_loss = self.loss(self.classifier(feats), y).mean()
+
+        # train generator/encoder to make discriminator classify feats as noise (label 1)
+        true_y = torch.tensor(feats.shape[0]*[1], device=feats.device, dtype=feats.dtype)
+        g_logits = self.discriminator(feats)
+        g_loss = self.discriminator_loss(g_logits.squeeze(1), true_y) # apply BCEWithLogitsLoss to discriminator's logit output
+        loss = ce_loss + self.hparams['urm_adv_lambda']*g_loss
+
+        return loss, feats
+
+    def update(self, minibatches, unlabeled=None):
+        if 'mixup_alpha' in self.hparams:
+            loss = 0
+
+            for (xi, yi), (xj, yj) in random_pairs_of_minibatches(minibatches):
+                lam = np.random.beta(self.hparams["mixup_alpha"],
+                                     self.hparams["mixup_alpha"])
+
+                x = lam * xi + (1 - lam) * xj
+                feats = self.featurizer(x)
+                predictions = self.classifier(feats)
+
+                if self.hparams['urm'] == 'adversarial':
+                    # train generator/encoder to make discriminator classify feats as noise (label 1)
+                    true_y = torch.tensor(feats.shape[0]*[1], device=feats.device, dtype=feats.dtype)
+                    g_logits = self.discriminator(feats)
+                    g_loss = self.discriminator_loss(g_logits.squeeze(1), true_y) # apply BCEWithLogitsLoss to discriminator's logit output
+                    g_loss = self.hparams['urm_adv_lambda']*g_loss
+                else:
+                    raise NotImplementedError
+
+                loss += lam * F.cross_entropy(predictions, yi)
+                loss += (1 - lam) * F.cross_entropy(predictions, yj)
+                loss += g_loss
+
+            loss /= len(minibatches)
+        else:
+            all_x = torch.cat([x for x, y in minibatches])
+            all_y = torch.cat([y for x, y in minibatches])
+            
+            loss, feats = self._compute_loss(all_x, all_y)
+
+        self.optimizer.zero_grad()
+
+        loss.backward()
+        self.optimizer.step()
+
+        # update discriminator after updating encoder-classifier (alternating updates)
+        if 'mixup_alpha' in self.hparams:
+            for (xi, yi), (xj, yj) in random_pairs_of_minibatches(minibatches):
+                lam = np.random.beta(self.hparams["mixup_alpha"],
+                                     self.hparams["mixup_alpha"])
+
+                x = lam * xi + (1 - lam) * xj
+                feats = self.featurizer(x)
+                self._update_discriminator(None, None, feats)
+                break # update discriminator once only for a random mixup of minibatches from two domains (updating more than once will push the discriminator ahead of generator)
+
+        else:
+            self._update_discriminator(all_x, all_y, feats)
+    
+        return {'loss': loss.item()}
 
 class Fish(Algorithm):
     """

--- a/domainbed/hparams_registry.py
+++ b/domainbed/hparams_registry.py
@@ -172,6 +172,23 @@ def _hparams(algorithm, dataset, random_seed):
     elif algorithm == 'ERMPlusPlus':
         _hparam('linear_lr', 5e-5, lambda r: 10**r.uniform(-5, -3.5))
 
+    elif algorithm == 'URM':
+        _hparam('urm', 'adversarial', lambda r: str(r.choice(['adversarial']))) # 'adversarial'
+        
+        if args and args.mixup:
+            _hparam('mixup_alpha', 0.2, lambda r: 10**r.uniform(-1, 1))
+
+        _hparam('urm_adv_lambda', 0.1, lambda r: float(r.uniform(0,0.2)))
+        _hparam('urm_discriminator_label_smoothing', 0, lambda r: float(r.uniform(0, 0)))
+        _hparam('urm_discriminator_optimizer', 'adam', lambda r: str(r.choice(['adam'])))
+        _hparam('urm_discriminator_hidden_layers', 1, lambda r: int(r.choice([1,2,3])))
+        _hparam('urm_generator_output', 'tanh', lambda r: str(r.choice(['tanh', 'relu'])))
+                
+        if dataset in SMALL_IMAGES:
+            _hparam('urm_discriminator_lr', 1e-3, lambda r: 10**r.uniform(-5.5, -3.5))
+        else:
+            _hparam('urm_discriminator_lr', 5e-5, lambda r: 10**r.uniform(-6, -4.5))
+
 
     if algorithm == "ADRMX":
         _hparam('cnt_lambda', 1.0, lambda r: r.choice([1.0]))

--- a/domainbed/hparams_registry.py
+++ b/domainbed/hparams_registry.py
@@ -175,9 +175,6 @@ def _hparams(algorithm, dataset, random_seed):
     elif algorithm == 'URM':
         _hparam('urm', 'adversarial', lambda r: str(r.choice(['adversarial']))) # 'adversarial'
         
-        if args and args.mixup:
-            _hparam('mixup_alpha', 0.2, lambda r: 10**r.uniform(-1, 1))
-
         _hparam('urm_adv_lambda', 0.1, lambda r: float(r.uniform(0,0.2)))
         _hparam('urm_discriminator_label_smoothing', 0, lambda r: float(r.uniform(0, 0)))
         _hparam('urm_discriminator_optimizer', 'adam', lambda r: str(r.choice(['adam'])))

--- a/domainbed/lib/wide_resnet.py
+++ b/domainbed/lib/wide_resnet.py
@@ -84,6 +84,8 @@ class Wide_ResNet(nn.Module):
 
         self.n_outputs = nStages[3]
 
+        self.activation = nn.Identity() # for URM; does not affect other algorithms
+
     def _wide_layer(self, block, planes, num_blocks, dropout_rate, stride):
         strides = [stride] + [1] * (int(num_blocks) - 1)
         layers = []
@@ -101,4 +103,6 @@ class Wide_ResNet(nn.Module):
         out = self.layer3(out)
         out = F.relu(self.bn1(out))
         out = F.avg_pool2d(out, 8)
-        return out[:, :, 0, 0]
+        out = out[:, :, 0, 0]
+        out = self.activation(out)
+        return out

--- a/domainbed/networks.py
+++ b/domainbed/networks.py
@@ -55,6 +55,7 @@ class MLP(nn.Module):
             for _ in range(hparams['mlp_depth']-2)])
         self.output = nn.Linear(hparams['mlp_width'], n_outputs)
         self.n_outputs = n_outputs
+        self.activation = nn.Identity() # for URM; does not affect other algorithms
 
     def forward(self, x):
         x = self.input(x)
@@ -65,6 +66,7 @@ class MLP(nn.Module):
             x = self.dropout(x)
             x = F.relu(x)
         x = self.output(x)
+        x = self.activation(x) # for URM; does not affect other algorithms
         return x
 
 class DinoV2(torch.nn.Module):
@@ -140,10 +142,11 @@ class ResNet(torch.nn.Module):
             self.freeze_bn()
         self.hparams = hparams
         self.dropout = nn.Dropout(hparams['resnet_dropout'])
+        self.activation = nn.Identity() # for URM; does not affect other algorithms
 
     def forward(self, x):
         """Encode x into a feature vector of size n_outputs."""
-        return self.dropout(self.network(x))
+        return self.activation(self.dropout(self.network(x)))
 
     def train(self, mode=True):
         """
@@ -181,6 +184,7 @@ class MNIST_CNN(nn.Module):
         self.bn3 = nn.GroupNorm(8, 128)
 
         self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
+        self.activation = nn.Identity() # for URM; does not affect other algorithms
 
     def forward(self, x):
         x = self.conv1(x)
@@ -201,7 +205,7 @@ class MNIST_CNN(nn.Module):
 
         x = self.avgpool(x)
         x = x.view(len(x), -1)
-        return x
+        return self.activation(x)
 
 
 class ContextNet(nn.Module):


### PR DESCRIPTION
I am first author of "Uniformly Distributed Feature Representations for Fair and Robust Learning" (TMLR 2024) paper. Link: https://openreview.net/forum?id=PgLbS5yp8n

In this pull request I am adding code for the proposed Uniform Risk Minimization (URM) method for domain generalization. The key idea is to encourage the distribution of feature representations learned by the encoder/featurizer to be uniformly distributed. The paper provides theoretical and empirical support for the proposed method for domain generalization and also robustness to sub-population shifts.

Changes include:

-  added `URM` class in `algorithms.py`
- added hyper-parameters in `hparams_registry.py`
- added method and link to paper in README.md
- modified `networks.py` and `lib/wide_resnet.py` to add an activation function to the output of the featurizer/encoder networks (before the linear classifier). This does not affect other algorithms in DomainBed as the default activation is nn.Identity(): https://github.com/kiranchari/DomainBed/blob/2b47e0ce5f6ad6560c93ba4a40c3aa617ca78053/domainbed/lib/wide_resnet.py#L87

Thank you.