### PR TITLE
Achieve simple multi-GPU training by DistributedDataParallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,19 @@ python3 -m domainbed.scripts.download \
 Train a model:
 
 ```sh
+# one GPU
 python3 -m domainbed.scripts.train\
        --data_dir=./domainbed/data/MNIST/\
        --algorithm IGA\
        --dataset ColoredMNIST\
        --test_env 2
+# multi-GPU
+torchrun --nproc_per_node=NUM_OF_YOUR_GPU \
+ -m domainbed.scripts.train\
+ --dataset 'VLCS' \
+ --algorithm ERM \
+ --data_dir "/VLCS" \
+ --test_envs 1
 ```
 
 Launch a sweep:

--- a/domainbed/algorithms.py
+++ b/domainbed/algorithms.py
@@ -124,6 +124,9 @@ class ERM(Algorithm):
     def predict(self, x):
         return self.network(x)
 
+    def forward(self, x):
+        return self.network(x)
+
 class ERMPlusPlus(Algorithm,ErmPlusPlusMovingAvg):
     """
     Empirical Risk Minimization with improvements (ERM++)


### PR DESCRIPTION
## Enable multi-GPU training for DomainBed using PyTorch DistributedDataParallel

### Main Modifications
`train.py`:

- Added DDP initialization using torch.distributed.init_process_group().
- Wrapped the model with torch.nn.parallel.DistributedDataParallel.
- Adjusted device handling for multiple processes.

`misc.py`:

- Modified the accuracy() function to support DDP.
- Added torch.distributed.all_reduce() to aggregate results across GPUs.

`fast_data_loader.py`:

- Modified FastDataLoader and InfiniteDataLoader to use DistributedSampler when in DDP mode.
- Ensures correct data shuffling and partitioning across GPUs.

`algorithms.py`:

- Added a forward() method to ERM for DDP compatibility (so model(x) works as expected).

`README.md`:

Documented usage of torchrun for launching multi-GPU training, e.g.:

```
torchrun --nproc_per_node=NUM_OF_YOUR_GPU \
 -m domainbed.scripts.train\
 --dataset 'VLCS' \
 --algorithm ERM \
 --data_dir "/VLCS" \
 --test_envs 1
```
Only for training, multiple GPU adaptations were made, and no corresponding modifications were made to other DomainBed features.